### PR TITLE
Security: TLS certificate validation is explicitly disabled for client connections

### DIFF
--- a/clusterpost/src/clusterpost-app/post.js
+++ b/clusterpost/src/clusterpost-app/post.js
@@ -7,7 +7,7 @@ const os = require('os');
 
 
 var agentoptions = {
-    rejectUnauthorized: false
+    rejectUnauthorized: true
 }
 
 clusterpost.setAgentOptions(agentoptions);


### PR DESCRIPTION
## Summary

Security: TLS certificate validation is explicitly disabled for client connections

## Problem

**Severity**: `High` | **File**: `clusterpost/src/clusterpost-app/post.js:L9`

The CLI configures HTTP(S) agent options with `rejectUnauthorized: false`, which disables TLS certificate verification. This allows man-in-the-middle attackers to intercept or tamper with traffic (including credentials, tokens, and job payloads) when communicating with remote services.

## Solution

Remove `rejectUnauthorized: false` and rely on default certificate validation. If self-signed certs are needed for development, gate this behind an explicit non-production flag and provide a trusted CA bundle instead of disabling verification globally.

## Changes

- `clusterpost/src/clusterpost-app/post.js` (modified)