### PR TITLE
Fix typos in the documentation

### DIFF
--- a/clusterpost/bigchaindb/bigchaindb/common/schema/README.md
+++ b/clusterpost/bigchaindb/bigchaindb/common/schema/README.md
@@ -39,7 +39,7 @@ It provides a *more accessible documentation for JSON schema* than the [specs](h
 
 ## If it's supposed to be JSON, why's everything in YAML D:?
 
-YAML is great for its conciseness and friendliness towards human-editing in comparision to JSON.
+YAML is great for its conciseness and friendliness towards human-editing in comparison to JSON.
 
 Although YAML is a superset of JSON, at the end of the day, JSON Schema processors, like
 [json-schema](http://python-jsonschema.readthedocs.io/en/latest/), take in a native object (e.g.

--- a/clusterpost/bigchaindb/docs/contributing/source/dev-setup-coding-and-contribution-process/run-dev-network-ansible.md
+++ b/clusterpost/bigchaindb/docs/contributing/source/dev-setup-coding-and-contribution-process/run-dev-network-ansible.md
@@ -30,7 +30,7 @@ $ git clone https://github.com/bigchaindb/bigchaindb.git
 ## Install dependencies
 - [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html)
 
-You can also install `ansible` and other dependencies, if any, using the `boostrap.sh` script
+You can also install `ansible` and other dependencies, if any, using the `bootstrap.sh` script
 inside the BigchainDB repository.
 Navigate to `bigchaindb/pkg/scripts` and run the `bootstrap.sh` script to install the dependencies
 for your OS. The script also checks if the OS you are running is compatible with the

--- a/clusterpost/bigchaindb/docs/server/source/events/websocket-event-stream-api.rst
+++ b/clusterpost/bigchaindb/docs/server/source/events/websocket-event-stream-api.rst
@@ -47,7 +47,7 @@ response contains a ``streams`` property:
 Connection Keep-Alive
 ---------------------
 
-The Event Stream API supports Ping/Pong frames as descibed in
+The Event Stream API supports Ping/Pong frames as described in
 `RFC 6455  <https://tools.ietf.org/html/rfc6455#section-5.5.2>`_.
 
 .. note::

--- a/clusterpost/bigchaindb/docs/server/source/k8s-deployment-template/bigchaindb-network-on-kubernetes.rst
+++ b/clusterpost/bigchaindb/docs/server/source/k8s-deployment-template/bigchaindb-network-on-kubernetes.rst
@@ -60,7 +60,7 @@ cluster is using.
   Currently, we only support a static set of participants in the network.
   Once a BigchainDB network is started with a certain number of validators
   and a genesis file. Users cannot add new validator nodes dynamically.
-  You can track the progress of this funtionality on our
+  You can track the progress of this functionality on our
   `github repository <https://github.com/bigchaindb/bigchaindb/milestones>`_.
 
 
@@ -244,7 +244,7 @@ the ``mongo-node-1-ss.yaml`` and update the corresponding ConfigMapKeyRef.name o
 .. code:: text
 
   ########################################################################
-  # This YAML file desribes a StatefulSet with a service for running and #
+  # This YAML file describes a StatefulSet with a service for running and #
   # exposing a MongoDB instance.                                         #
   # It depends on the configdb and db k8s pvc.                           #
   ########################################################################

--- a/clusterpost/bigchaindb/docs/server/source/k8s-deployment-template/node-on-kubernetes.rst
+++ b/clusterpost/bigchaindb/docs/server/source/k8s-deployment-template/node-on-kubernetes.rst
@@ -372,7 +372,7 @@ but it should become "Bound" fairly quickly.
     The default Reclaim Policy for dynamically created persistent volumes is ``Delete``
     which means the PV and its associated Azure storage resource will be automatically
     deleted on deletion of PVC or PV. In order to prevent this from happening do
-    the following steps to change default reclaim policy of dyanmically created PVs
+    the following steps to change default reclaim policy of dynamically created PVs
     from ``Delete`` to ``Retain``
 
     * Run the following command to list existing PVs

--- a/clusterpost/bigchaindb/docs/server/source/k8s-deployment-template/revoke-tls-certificate.rst
+++ b/clusterpost/bigchaindb/docs/server/source/k8s-deployment-template/revoke-tls-certificate.rst
@@ -45,4 +45,4 @@ Generate a new CRL for your infrastructure using:
 The generated ``crl.pem`` file needs to be uploaded to your infrastructure to
 prevent the revoked certificate from being used again.
 
-In particlar, the generated ``crl.pem`` file should be sent to all BigchainDB node operators in your BigchainDB network, so that they can update it in their MongoDB instance and their BigchainDB Server instance.
+In particular, the generated ``crl.pem`` file should be sent to all BigchainDB node operators in your BigchainDB network, so that they can update it in their MongoDB instance and their BigchainDB Server instance.

--- a/clusterpost/bigchaindb/docs/server/source/k8s-deployment-template/server-tls-certificate.rst
+++ b/clusterpost/bigchaindb/docs/server/source/k8s-deployment-template/server-tls-certificate.rst
@@ -38,7 +38,7 @@ and using something like:
 
 .. note::
 
-    Please make sure you are fullfilling the requirements for `MongoDB server/member certificates
+    Please make sure you are fulfilling the requirements for `MongoDB server/member certificates
     <https://docs.mongodb.com/manual/tutorial/configure-x509-member-authentication>`_.
 
 .. code:: bash

--- a/clusterpost/bigchaindb/docs/server/source/k8s-deployment-template/tectonic-azure.rst
+++ b/clusterpost/bigchaindb/docs/server/source/k8s-deployment-template/tectonic-azure.rst
@@ -106,7 +106,7 @@ when following the steps above:
    ``ARM_CLIENT_SECRET``.
 
 #. Note that the URL for the Tectonic console using these settings will be the
-   cluster name set in the configutation file, the datacenter name and
+   cluster name set in the configuration file, the datacenter name and
    ``cloudapp.azure.com``. For example, if you named your cluster as 
    ``test-cluster`` and specified the datacenter as ``westeurope``, the Tectonic
    console will be available at ``test-cluster.westeurope.cloudapp.azure.com``.

--- a/clusterpost/bigchaindb/docs/server/source/k8s-deployment-template/template-kubernetes-azure.rst
+++ b/clusterpost/bigchaindb/docs/server/source/k8s-deployment-template/template-kubernetes-azure.rst
@@ -43,7 +43,7 @@ Step 2: Create an SSH Key Pair
 
 You'll want an SSH key pair so you'll be able to SSH
 to the virtual machines that you'll deploy in the next step.
-(If you already have an SSH key pair, you *could* reuse it,
+(If you already have an SSH key pair, you *could* re-use it,
 but it's probably a good idea to make a new SSH key pair
 for your Kubernetes VMs and nothing else.)
 

--- a/clusterpost/bigchaindb/docs/server/source/k8s-deployment-template/upgrade-on-kubernetes.rst
+++ b/clusterpost/bigchaindb/docs/server/source/k8s-deployment-template/upgrade-on-kubernetes.rst
@@ -56,7 +56,7 @@ to update the OS and Docker.
 .. note::
 
    Once you are in an SSH session with a host,
-   the ``docker info`` command is a handy way to detemine the
+   the ``docker info`` command is a handy way to determine the
    host OS (including version) and the Docker version.
 
 When you want to upgrade the software on a Kubernetes node,

--- a/clusterpost/bigchaindb/docs/server/source/k8s-deployment-template/workflow.rst
+++ b/clusterpost/bigchaindb/docs/server/source/k8s-deployment-template/workflow.rst
@@ -28,7 +28,7 @@ You can modify them to suit your needs.
 Generate All Shared BigchainDB Setup Parameters
 -----------------------------------------------
 
-There are some shared BigchainDB setup paramters that every node operator
+There are some shared BigchainDB setup parameters that every node operator
 in the consortium shares
 because they are properties of the Tendermint network.
 They look like this:

--- a/clusterpost/bigchaindb/docs/upgrade-guides/v0.10-v1.0.md
+++ b/clusterpost/bigchaindb/docs/upgrade-guides/v0.10-v1.0.md
@@ -116,7 +116,7 @@ reach out to us for help on GitHub/Gitter or devs@bigchaindb.com.
 #### Revamp of Crypto-Conditions signing details
 
 In order to create a correct fulfillment for an output condition in BigchainDB,
-we include the conditon URI ("ni:///sha-256;..."), to verify the fulfillment
+we include the condition URI ("ni:///sha-256;..."), to verify the fulfillment
 against. However, the condition URI does not tell you who may sign in order to
 create a correct fulfillment.
 

--- a/clusterpost/bigchaindb/k8s/bigchaindb/bigchaindb-pv.yaml
+++ b/clusterpost/bigchaindb/k8s/bigchaindb/bigchaindb-pv.yaml
@@ -3,7 +3,7 @@
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
 #########################################################
-# This YAML section desribes a k8s PV for tendermint db #
+# This YAML section describes a k8s PV for tendermint db #
 #########################################################
 apiVersion: v1
 kind: PersistentVolume

--- a/clusterpost/bigchaindb/k8s/bigchaindb/bigchaindb-pvc.yaml
+++ b/clusterpost/bigchaindb/k8s/bigchaindb/bigchaindb-pvc.yaml
@@ -3,7 +3,7 @@
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
 ##########################################################
-# This section file desribes a k8s pvc for tendermint db #
+# This section file describes a k8s pvc for tendermint db #
 ##########################################################
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/clusterpost/bigchaindb/k8s/bigchaindb/bigchaindb-sc.yaml
+++ b/clusterpost/bigchaindb/k8s/bigchaindb/bigchaindb-sc.yaml
@@ -3,7 +3,7 @@
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
 ###################################################################
-# This YAML section desribes a StorageClass for the tendermint db #
+# This YAML section describes a StorageClass for the tendermint db #
 ###################################################################
 kind: StorageClass
 apiVersion: storage.k8s.io/v1beta1

--- a/clusterpost/bigchaindb/k8s/bigchaindb/bigchaindb-ss.yaml
+++ b/clusterpost/bigchaindb/k8s/bigchaindb/bigchaindb-ss.yaml
@@ -3,7 +3,7 @@
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
 #################################################################################
-# This YAML file desribes a StatefulSet with a service for running and exposing #
+# This YAML file describes a StatefulSet with a service for running and exposing #
 # a Tendermint instance. It depends on the tendermint-config-db-claim           #
 # and tendermint-db-claim k8s pvc.                                              #
 #################################################################################

--- a/clusterpost/bigchaindb/k8s/bigchaindb/tendermint_container/README.md
+++ b/clusterpost/bigchaindb/k8s/bigchaindb/tendermint_container/README.md
@@ -19,7 +19,7 @@ reflect any changes made to the container.
 docker run \
   --name=tendermint \
   --env TM_PUB_KEY_ACCESS_PORT=<port to access public keys hosted by nginx> \
-  --env TM_PERSISTENT_PEERS=<commad separated list of all peers IP addresses/Hostnames> \
+  --env TM_PERSISTENT_PEERS=<command separated list of all peers IP addresses/Hostnames> \
   --env TM_VALIDATOR_POWER=<voting power of node> \
   --env TM_VALIDATORS=<list of all validators> \
   --env TM_GENESIS_TIME=<genesis time> \

--- a/clusterpost/bigchaindb/k8s/mongodb/mongo-pv.yaml
+++ b/clusterpost/bigchaindb/k8s/mongodb/mongo-pv.yaml
@@ -3,7 +3,7 @@
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
 #############################################################
-# This YAML section desribes a k8s PV for mongodb dbPath    #
+# This YAML section describes a k8s PV for mongodb dbPath    #
 #############################################################
 apiVersion: v1
 kind: PersistentVolume

--- a/clusterpost/bigchaindb/k8s/mongodb/mongo-pvc.yaml
+++ b/clusterpost/bigchaindb/k8s/mongodb/mongo-pvc.yaml
@@ -3,7 +3,7 @@
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
 ###########################################################
-# This section file desribes a k8s pvc for mongodb dbPath #
+# This section file describes a k8s pvc for mongodb dbPath #
 ###########################################################
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/clusterpost/bigchaindb/k8s/mongodb/mongo-sc.yaml
+++ b/clusterpost/bigchaindb/k8s/mongodb/mongo-sc.yaml
@@ -3,7 +3,7 @@
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
 ####################################################################
-# This YAML section desribes a StorageClass for the mongodb dbPath #
+# This YAML section describes a StorageClass for the mongodb dbPath #
 ####################################################################
 kind: StorageClass
 apiVersion: storage.k8s.io/v1beta1

--- a/clusterpost/bigchaindb/k8s/mongodb/mongo-ss.yaml
+++ b/clusterpost/bigchaindb/k8s/mongodb/mongo-ss.yaml
@@ -3,7 +3,7 @@
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
 ########################################################################
-# This YAML file desribes a StatefulSet with a service for running and #
+# This YAML file describes a StatefulSet with a service for running and #
 # exposing a MongoDB instance.                                         #
 # It depends on the configdb and db k8s pvc.                           #
 ########################################################################

--- a/clusterpost/bigchaindb/proposals/extend-post-txn.md
+++ b/clusterpost/bigchaindb/proposals/extend-post-txn.md
@@ -37,7 +37,7 @@ The query parameter `mode` will be introduced to [`POST /api/v1/transaction`](ht
 - `sync`
 - `commit`
 
-To preserve compability with the existing behavour of the API, the query parameter `mode` is optional. In this case the default value would be `async`.
+To preserve compatibility with the existing behaviour of the API, the query parameter `mode` is optional. In this case the default value would be `async`.
 
 
 example URI: `/api/v1/transaction?mode=async`

--- a/clusterpost/bigchaindb/proposals/integration-testing.md
+++ b/clusterpost/bigchaindb/proposals/integration-testing.md
@@ -44,7 +44,7 @@ The `ND` module implements two main functions:
 In the next sections we will use `ND` to refer to the Python class, and `network` to refer to an instance of it. For now, `network` will most likely be a singleton, since it will control `docker` in the current host. This **will not** be the final name of the module.
 
 ### Usage example
-The following code is just a suggestion on how the new module shuold be used. It may contain syntax errors or other kind of errors.
+The following code is just a suggestion on how the new module should be used. It may contain syntax errors or other kind of errors.
 
 ```python
 def test_valid_transaction_is_available_in_all_nodes(network):

--- a/clusterpost/doc/install.txt
+++ b/clusterpost/doc/install.txt
@@ -63,7 +63,7 @@ This email account will be used to send a token to the user to reset the passwor
 
 Check https://github.com/nodemailer/nodemailer[nodemailer] for possible configurations
 
-==== Generate random key for pasword encryption
+==== Generate random key for password encryption
 
 An easy way to generate a random key is done by typing the command
 

--- a/clusterpost/src/clusterpost-provider/README.md
+++ b/clusterpost/src/clusterpost-provider/README.md
@@ -15,7 +15,7 @@ For more information about the type of computing grids that are supported check 
 
 This package depends on [hapi-jwt-couch](https://www.npmjs.com/package/hapi-jwt-couch), 
 for the route authentication and encryption of tokens. 
-The algorithm section has the parameters to encrypt the tokens that are emmited for the clusterpost-execution.
+The algorithm section has the parameters to encrypt the tokens that are emitted for the clusterpost-execution.
 
 ----
 	var obj_config = {

--- a/clusterpost/src/couch-update-views/README.md
+++ b/clusterpost/src/couch-update-views/README.md
@@ -32,7 +32,7 @@ You should see the following output:
     Options:
 	    --migrate    Migrate design documents in couchdb. The 'design views' in couchdb are updated with the contents of the 'viewsDir' folder if they differ.
 	    --update  <design view name>   Update the design view document stored in 'viewsDirs' with the document stored in 'couchDB'    
-	    --viewsDir <path>   Directory with desgin views documents JSON files. (required)
+	    --viewsDir <path>   Directory with design views documents JSON files. (required)
 	    --couchDB  <url>    CouchDB URL. (required)
 ----
 

--- a/packages/dfarm/README.md
+++ b/packages/dfarm/README.md
@@ -4,7 +4,7 @@
 
 ![DFarmUML](https://raw.githubusercontent.com/Mentors4EDU/Images/master/DfarmUML.png)
 
-This is a plugin/extension for the Farmbot to syncronize its web interface and monitoring activity with the Decentralized Internet SDK. This is done by basically syncing to the database host of the SDK, as well as calling its pipeline for various data access points. Currently, the configurations are being worked on.
+This is a plugin/extension for the Farmbot to synchronize its web interface and monitoring activity with the Decentralized Internet SDK. This is done by basically syncing to the database host of the SDK, as well as calling its pipeline for various data access points. Currently, the configurations are being worked on.
 
 Todo:
 - Database host configs

--- a/packages/p2lara/src/storages/bigchaindb/common/schema/README.md
+++ b/packages/p2lara/src/storages/bigchaindb/common/schema/README.md
@@ -39,7 +39,7 @@ It provides a *more accessible documentation for JSON schema* than the [specs](h
 
 ## If it's supposed to be JSON, why's everything in YAML D:?
 
-YAML is great for its conciseness and friendliness towards human-editing in comparision to JSON.
+YAML is great for its conciseness and friendliness towards human-editing in comparison to JSON.
 
 Although YAML is a superset of JSON, at the end of the day, JSON Schema processors, like
 [json-schema](http://python-jsonschema.readthedocs.io/en/latest/), take in a native object (e.g.

--- a/packages/p2pwiki/contributing.md
+++ b/packages/p2pwiki/contributing.md
@@ -24,7 +24,7 @@ As the project is split into a number of repositories/npm packages, we need to b
 
 `npm install` works by installing the package from the repository you are working on. The downside is that you need to run the install each time you rebuild the component. See [npm-install](https://npmjs.org/doc/cli/npm-install.html) man page.
 
-You will need a local copy of the *wiki* package, this can either be from GitHub, or installed from npm (though using git is probably simplier).
+You will need a local copy of the *wiki* package, this can either be from GitHub, or installed from npm (though using git is probably simpler).
 
 If, for example, you were working on the `method` plug-in, you would do something like the following:
 


### PR DESCRIPTION
Fixes 30 spelling mistakes in the docs, found with `codespell`.

Prose only. No code identifiers, dependency names or proper nouns changed, and left alone anything that was a valid word rather than a misspelling.